### PR TITLE
Configure treesitter

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -55,6 +55,22 @@
         "type": "github"
       }
     },
+    "plugin:nvim-treesitter-context": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689239188,
+        "narHash": "sha256-AJamiDezFK7l0bqb/VFm+pzBKugQNCmQ6JAWKmjH76g=",
+        "owner": "nvim-treesitter",
+        "repo": "nvim-treesitter-context",
+        "rev": "6f8f788738b968f24a108ee599c5be0031f94f06",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-treesitter",
+        "repo": "nvim-treesitter-context",
+        "type": "github"
+      }
+    },
     "plugin:rose-pine": {
       "flake": false,
       "locked": {
@@ -91,6 +107,7 @@
       "inputs": {
         "neovim": "neovim",
         "nixpkgs": "nixpkgs",
+        "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
         "plugin:rose-pine": "plugin:rose-pine",
         "plugin:vim-ledger": "plugin:vim-ledger"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    "plugin:nvim-treesitter-context" = {
+      url = github:nvim-treesitter/nvim-treesitter-context;
+      flake = false;
+    };
+
     "plugin:rose-pine" = {
       url = github:rose-pine/neovim;
       flake = false;

--- a/pkgs/config/after/plugin/colors.lua
+++ b/pkgs/config/after/plugin/colors.lua
@@ -1,1 +1,5 @@
+require("rose-pine").setup({
+    disable_italics = true,
+})
+
 vim.cmd.colorscheme("rose-pine")

--- a/pkgs/config/after/plugin/treesitter.lua
+++ b/pkgs/config/after/plugin/treesitter.lua
@@ -1,0 +1,22 @@
+require("nvim-treesitter.configs").setup({
+    -- A list of parser names, or "all"
+    ensure_installed = {},
+
+    -- Install parsers synchronously (only applied to `ensure_installed`)
+    sync_install = false,
+
+    -- Automatically install missing parsers when entering buffer
+    -- Recommendation: set to false if you don't have `tree-sitter` CLI installed locally
+    auto_install = false,
+
+    highlight = {
+        -- `false` will disable the whole extension
+        enable = true,
+
+        -- Setting this to true will run `:h syntax` and tree-sitter at the same time.
+        -- Set this to `true` if you depend on 'syntax' being enabled (like for indentation).
+        -- Using this option may slow down your editor, and you may see some duplicate highlights.
+        -- Instead of true it can also be a list of languages
+        additional_vim_regex_highlighting = false,
+    },
+})

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -9,8 +9,9 @@
   extraPackages ? [],
 }: let
   plugins = [
-    pkgs.neovimPlugins.vim-ledger
+    pkgs.vimPlugins.nvim-treesitter.withAllGrammars
     pkgs.neovimPlugins.rose-pine
+    pkgs.neovimPlugins.vim-ledger
   ];
 
   nvimConfig = pkgs.neovimUtils.makeNeovimConfig {

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -10,6 +10,7 @@
 }: let
   plugins = [
     pkgs.vimPlugins.nvim-treesitter.withAllGrammars
+    pkgs.neovimPlugins.nvim-treesitter-context
     pkgs.neovimPlugins.rose-pine
     pkgs.neovimPlugins.vim-ledger
   ];


### PR DESCRIPTION
- Install and configure the `nvim-treesitter` plugin from nixpkgs, rather than directly the GitHub repo. This is because the package in nixpkgs comes with a handy `nvim-treesitter.withAllGrammars` variant that includes all grammars treesitter supports. Without this, I would need to manually build and install each of the grammars that I'd want - which is a lot!
- Install and configure the `nvim-treesitter-context` plugin, which just displays context (i.e. function declaration) at the top of the window.
- Stop rose-pine from using italics