### PR TITLE
Bring inline with dotfiles

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -87,6 +87,22 @@
         "type": "github"
       }
     },
+    "plugin:plenary-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1689589150,
+        "narHash": "sha256-oRtNcURQzrIRS3D88tWAl3HuFHxVJr8m/zzL7xoa/II=",
+        "owner": "nvim-lua",
+        "repo": "plenary.nvim",
+        "rev": "267282a9ce242bbb0c5dc31445b6d353bed978bb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-lua",
+        "repo": "plenary.nvim",
+        "type": "github"
+      }
+    },
     "plugin:rose-pine": {
       "flake": false,
       "locked": {
@@ -100,6 +116,22 @@
       "original": {
         "owner": "rose-pine",
         "repo": "neovim",
+        "type": "github"
+      }
+    },
+    "plugin:telescope-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690663693,
+        "narHash": "sha256-okyOr5t0e+oV3mY7Yq1ad/7f6qEEDS/ZQrqJcjktYRI=",
+        "owner": "nvim-telescope",
+        "repo": "telescope.nvim",
+        "rev": "b6fccfb0f7589a87587875206786daccba62acc3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nvim-telescope",
+        "repo": "telescope.nvim",
         "type": "github"
       }
     },
@@ -173,7 +205,9 @@
         "nixpkgs": "nixpkgs",
         "plugin:comment-nvim": "plugin:comment-nvim",
         "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
+        "plugin:plenary-nvim": "plugin:plenary-nvim",
         "plugin:rose-pine": "plugin:rose-pine",
+        "plugin:telescope-nvim": "plugin:telescope-nvim",
         "plugin:vim-fugitive": "plugin:vim-fugitive",
         "plugin:vim-ledger": "plugin:vim-ledger",
         "plugin:vim-sleuth": "plugin:vim-sleuth",

--- a/flake.lock
+++ b/flake.lock
@@ -199,6 +199,22 @@
         "type": "github"
       }
     },
+    "plugin:which-key-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690570286,
+        "narHash": "sha256-B1+EHd2eH/EbD5Kip9PfhdPyyGfIkD6rsx0Z3rXvb5w=",
+        "owner": "folke",
+        "repo": "which-key.nvim",
+        "rev": "7ccf476ebe0445a741b64e36c78a682c1c6118b7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "folke",
+        "repo": "which-key.nvim",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "neovim": "neovim",
@@ -211,7 +227,8 @@
         "plugin:vim-fugitive": "plugin:vim-fugitive",
         "plugin:vim-ledger": "plugin:vim-ledger",
         "plugin:vim-sleuth": "plugin:vim-sleuth",
-        "plugin:vim-surround": "plugin:vim-surround"
+        "plugin:vim-surround": "plugin:vim-surround",
+        "plugin:which-key-nvim": "plugin:which-key-nvim"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -103,6 +103,22 @@
         "type": "github"
       }
     },
+    "plugin:vim-fugitive": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688507093,
+        "narHash": "sha256-JAlILa/7A9L10nWJh7IIfhdNn1tpVSKyhuc0oGTekvg=",
+        "owner": "tpope",
+        "repo": "vim-fugitive",
+        "rev": "b3b838d690f315a503ec4af8c634bdff3b200aaf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tpope",
+        "repo": "vim-fugitive",
+        "type": "github"
+      }
+    },
     "plugin:vim-ledger": {
       "flake": false,
       "locked": {
@@ -119,6 +135,38 @@
         "type": "github"
       }
     },
+    "plugin:vim-sleuth": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673378030,
+        "narHash": "sha256-ClltfSVuoNoq5EiWRVBsGz1mrr7FbafGDdgsavLgFVE=",
+        "owner": "tpope",
+        "repo": "vim-sleuth",
+        "rev": "1cc4557420f215d02c4d2645a748a816c220e99b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tpope",
+        "repo": "vim-sleuth",
+        "type": "github"
+      }
+    },
+    "plugin:vim-surround": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1666730476,
+        "narHash": "sha256-DZE5tkmnT+lAvx/RQHaDEgEJXRKsy56KJY919xiH1lE=",
+        "owner": "tpope",
+        "repo": "vim-surround",
+        "rev": "3d188ed2113431cf8dac77be61b842acb64433d9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "tpope",
+        "repo": "vim-surround",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "neovim": "neovim",
@@ -126,7 +174,10 @@
         "plugin:comment-nvim": "plugin:comment-nvim",
         "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
         "plugin:rose-pine": "plugin:rose-pine",
-        "plugin:vim-ledger": "plugin:vim-ledger"
+        "plugin:vim-fugitive": "plugin:vim-fugitive",
+        "plugin:vim-ledger": "plugin:vim-ledger",
+        "plugin:vim-sleuth": "plugin:vim-sleuth",
+        "plugin:vim-surround": "plugin:vim-surround"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -55,6 +55,22 @@
         "type": "github"
       }
     },
+    "plugin:comment-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1686546603,
+        "narHash": "sha256-XM9yhp+SGxfAOdN/eDunzM0TMoCJhVth3wpFKNCGf3g=",
+        "owner": "numToStr",
+        "repo": "Comment.nvim",
+        "rev": "176e85eeb63f1a5970d6b88f1725039d85ca0055",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numToStr",
+        "repo": "Comment.nvim",
+        "type": "github"
+      }
+    },
     "plugin:nvim-treesitter-context": {
       "flake": false,
       "locked": {
@@ -107,6 +123,7 @@
       "inputs": {
         "neovim": "neovim",
         "nixpkgs": "nixpkgs",
+        "plugin:comment-nvim": "plugin:comment-nvim",
         "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
         "plugin:rose-pine": "plugin:rose-pine",
         "plugin:vim-ledger": "plugin:vim-ledger"

--- a/flake.nix
+++ b/flake.nix
@@ -23,8 +23,23 @@
       flake = false;
     };
 
+    "plugin:vim-fugitive" = {
+      url = github:tpope/vim-fugitive;
+      flake = false;
+    };
+
     "plugin:vim-ledger" = {
       url = github:ledger/vim-ledger;
+      flake = false;
+    };
+
+    "plugin:vim-sleuth" = {
+      url = github:tpope/vim-sleuth;
+      flake = false;
+    };
+
+    "plugin:vim-surround" = {
+      url = github:tpope/vim-surround;
       flake = false;
     };
   };

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,11 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    "plugin:comment-nvim" = {
+      url = github:numToStr/Comment.nvim;
+      flake = false;
+    };
+
     "plugin:nvim-treesitter-context" = {
       url = github:nvim-treesitter/nvim-treesitter-context;
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -23,6 +23,16 @@
       flake = false;
     };
 
+    "plugin:plenary-nvim" = {
+      url = github:nvim-lua/plenary.nvim;
+      flake = false;
+    };
+
+    "plugin:telescope-nvim" = {
+      url = github:nvim-telescope/telescope.nvim;
+      flake = false;
+    };
+
     "plugin:vim-fugitive" = {
       url = github:tpope/vim-fugitive;
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -52,6 +52,11 @@
       url = github:tpope/vim-surround;
       flake = false;
     };
+
+    "plugin:which-key-nvim" = {
+      url = github:folke/which-key.nvim;
+      flake = false;
+    };
   };
 
   outputs = {self, ...} @ inputs: let

--- a/pkgs/config/after/plugin/colors.lua
+++ b/pkgs/config/after/plugin/colors.lua
@@ -1,5 +1,8 @@
 require("rose-pine").setup({
     disable_italics = true,
+    highlight_groups = {
+        ExtraWhitespace = { bg = "love", blend = 75 },
+    },
 })
 
 vim.cmd.colorscheme("rose-pine")

--- a/pkgs/config/after/plugin/comment.lua
+++ b/pkgs/config/after/plugin/comment.lua
@@ -1,0 +1,1 @@
+require("Comment").setup()

--- a/pkgs/config/after/plugin/telescope.lua
+++ b/pkgs/config/after/plugin/telescope.lua
@@ -1,0 +1,16 @@
+local builtin = require("telescope.builtin")
+
+-- Use that Ctrl-P muscle memory to find files in `git ls-files`
+vim.keymap.set("n", "<C-p>", builtin.git_files, {})
+
+-- Find files with <leader>pf (mnemonic: "Project Find")
+vim.keymap.set("n", "<leader>pf", builtin.find_files, {})
+
+-- Search for a string in project (mnemonic: "Project Search")
+vim.keymap.set("n", "<leader>ps", builtin.live_grep, {})
+
+-- Search through vim help tags (mnemonic: "Vim Help")
+vim.keymap.set("n", "<leader>vh", builtin.help_tags, {})
+
+-- Search through vim options (mnemonic: "Vim Options")
+vim.keymap.set("n", "<leader>vo", builtin.vim_options, {})

--- a/pkgs/config/after/plugin/telescope.lua
+++ b/pkgs/config/after/plugin/telescope.lua
@@ -1,16 +1,43 @@
 local builtin = require("telescope.builtin")
 
--- Use that Ctrl-P muscle memory to find files in `git ls-files`
-vim.keymap.set("n", "<C-p>", builtin.git_files, {})
+-- Find files
+vim.keymap.set(
+    "n",
+    "<C-p>",
+    builtin.git_files,
+    { desc = "Fuzzy find git-tracked files" }
+)
+vim.keymap.set(
+    "n",
+    "<leader>pf",
+    builtin.find_files,
+    { desc = "Project Find: Fuzzy find files" }
+)
 
--- Find files with <leader>pf (mnemonic: "Project Find")
-vim.keymap.set("n", "<leader>pf", builtin.find_files, {})
+-- Find string
+vim.keymap.set(
+    "n",
+    "<leader>ps",
+    builtin.live_grep,
+    { desc = "Project Search: Search across files" }
+)
+vim.keymap.set(
+    "n",
+    "<leader>/",
+    builtin.live_grep,
+    { desc = "Project Search: Search across files" }
+)
 
--- Search for a string in project (mnemonic: "Project Search")
-vim.keymap.set("n", "<leader>ps", builtin.live_grep, {})
-
--- Search through vim help tags (mnemonic: "Vim Help")
-vim.keymap.set("n", "<leader>vh", builtin.help_tags, {})
-
--- Search through vim options (mnemonic: "Vim Options")
-vim.keymap.set("n", "<leader>vo", builtin.vim_options, {})
+-- Find vim stuff
+vim.keymap.set(
+    "n",
+    "<leader>vh",
+    builtin.help_tags,
+    { desc = "Vim Help: Search vim help tags" }
+)
+vim.keymap.set(
+    "n",
+    "<leader>vo",
+    builtin.vim_options,
+    { desc = "Vim Options: Search vim options" }
+)

--- a/pkgs/config/after/plugin/which-key.lua
+++ b/pkgs/config/after/plugin/which-key.lua
@@ -1,0 +1,1 @@
+require("which-key").setup({})

--- a/pkgs/config/lua/jagd/hooks.lua
+++ b/pkgs/config/lua/jagd/hooks.lua
@@ -1,6 +1,7 @@
 local augroup = vim.api.nvim_create_augroup
 local autocmd = vim.api.nvim_create_autocmd
 
+-- Only show cursor line in current split
 local cursorline_group = augroup("cursorline", { clear = true })
 autocmd("WinLeave", {
     group = cursorline_group,
@@ -11,4 +12,18 @@ autocmd("WinEnter", {
     group = cursorline_group,
     pattern = "*",
     command = "set cursorline",
+})
+
+-- Show trailing whitespace (but not on current line or in insert mode)
+local extra_whitespace_group = augroup("extra_whitespace", { clear = true })
+vim.api.nvim_set_hl(0, "ExtraWhitespace", { bg = "red" })
+autocmd("InsertEnter", {
+    group = extra_whitespace_group,
+    pattern = "*",
+    command = "match ExtraWhitespace /\\s\\+\\%#\\@<!$/",
+})
+autocmd("InsertLeave", {
+    group = extra_whitespace_group,
+    pattern = "*",
+    command = "match ExtraWhitespace /\\s\\+$/",
 })

--- a/pkgs/config/lua/jagd/keymaps.lua
+++ b/pkgs/config/lua/jagd/keymaps.lua
@@ -1,11 +1,11 @@
 vim.g.mapleader = " "
 
--- Open netrw with <leader>pv (mnemonic: "Project View")
-vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
-
--- Move visual selection up/down with K/J
-vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv")
-vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
+vim.keymap.set(
+    "n",
+    "<leader>pv",
+    vim.cmd.Ex,
+    { desc = "Project View: Open Netrw" }
+)
 
 -- Make jumping with ctrl D/U stay centred in screen
 vim.keymap.set("n", "<C-d>", "<C-d>zz")
@@ -15,16 +15,33 @@ vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
 
--- Paste over visual selection without losing register contents
-vim.keymap.set("x", "<leader>p", [["_dP]])
-
--- Copy to system clipboard
-vim.keymap.set({ "n", "v" }, "<leader>y", [["+y]])
-vim.keymap.set("n", "<leader>Y", [["+Y]])
+vim.keymap.set(
+    { "n", "v" },
+    "<leader>y",
+    [["+y]],
+    { desc = "Copy to system clipboard" }
+)
+vim.keymap.set(
+    "n",
+    "<leader>Y",
+    [["+Y]],
+    { desc = "Copy rest of line to system clipboard" }
+)
 
 -- Stop accidentally pressing Q
 vim.keymap.set("n", "Q", "<nop>")
 
--- Re-select selction after indenting in visual mode
+-- Move visual selection up/down with K/J
+vim.keymap.set("v", "J", ":m '>+1<CR>gv=gv")
+vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
+
+-- Re-select selection after indenting in visual mode
 vim.keymap.set("v", ">", ">gv")
 vim.keymap.set("v", ">", "<gv")
+
+vim.keymap.set(
+    "x",
+    "<leader>p",
+    [["_dP]],
+    { desc = "Paste over visual selection without losing register contents" }
+)

--- a/pkgs/config/lua/jagd/keymaps.lua
+++ b/pkgs/config/lua/jagd/keymaps.lua
@@ -1,6 +1,6 @@
 vim.g.mapleader = " "
 
--- Open netrw with <leader>pv (mnemonic: "project view")
+-- Open netrw with <leader>pv (mnemonic: "Project View")
 vim.keymap.set("n", "<leader>pv", vim.cmd.Ex)
 
 -- Move visual selection up/down with K/J

--- a/pkgs/config/lua/jagd/options.lua
+++ b/pkgs/config/lua/jagd/options.lua
@@ -40,3 +40,22 @@ vim.opt.colorcolumn = "80"
 
 -- Highlight the line the cursor is on
 vim.opt.cursorline = true
+
+-- Search ignoring case unless search contains uppercase characters
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+
+-- Prefer splitting windows to the right and the bottom
+vim.opt.splitright = true
+vim.opt.splitbelow = true
+
+vim.opt.formatoptions = vim.opt.formatoptions
+    - "a" -- Don't automatically format
+    - "t" -- Don't auto-wrap text
+    + "c" -- Auto-wrap comments to textwidth
+    + "q" -- Allow comments to be formatted with `gq`
+    - "o" -- Don't insert comment when `o` or `O` -ing on a comment
+    + "r" -- But do continue a comment when hitting enter
+    - "n" -- Recognise numbered lists when formatting
+    + "j" -- Remove comment leaders when joining lines
+    - "2" -- Don't allow paragraphs to have a different indent on first line

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -18,6 +18,7 @@
     pkgs.neovimPlugins.vim-ledger
     pkgs.neovimPlugins.vim-sleuth
     pkgs.neovimPlugins.vim-surround
+    pkgs.neovimPlugins.which-key-nvim
     pkgs.vimPlugins.nvim-treesitter.withAllGrammars
   ];
 

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -11,7 +11,9 @@
   plugins = [
     pkgs.neovimPlugins.comment-nvim
     pkgs.neovimPlugins.nvim-treesitter-context
+    pkgs.neovimPlugins.plenary-nvim
     pkgs.neovimPlugins.rose-pine
+    pkgs.neovimPlugins.telescope-nvim
     pkgs.neovimPlugins.vim-fugitive
     pkgs.neovimPlugins.vim-ledger
     pkgs.neovimPlugins.vim-sleuth

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -10,6 +10,7 @@
 }: let
   plugins = [
     pkgs.vimPlugins.nvim-treesitter.withAllGrammars
+    pkgs.neovimPlugins.comment-nvim
     pkgs.neovimPlugins.nvim-treesitter-context
     pkgs.neovimPlugins.rose-pine
     pkgs.neovimPlugins.vim-ledger

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -9,11 +9,14 @@
   extraPackages ? [],
 }: let
   plugins = [
-    pkgs.vimPlugins.nvim-treesitter.withAllGrammars
     pkgs.neovimPlugins.comment-nvim
     pkgs.neovimPlugins.nvim-treesitter-context
     pkgs.neovimPlugins.rose-pine
+    pkgs.neovimPlugins.vim-fugitive
     pkgs.neovimPlugins.vim-ledger
+    pkgs.neovimPlugins.vim-sleuth
+    pkgs.neovimPlugins.vim-surround
+    pkgs.vimPlugins.nvim-treesitter.withAllGrammars
   ];
 
   nvimConfig = pkgs.neovimUtils.makeNeovimConfig {


### PR DESCRIPTION
This PR brings the neovim config in this repo inline with the [old vim config from my dotfiles](https://github.com/daviesjamie/dotfiles/blob/01cf9cdc50ab08ed5cbeaac74ca4b55a8ef218a3/vim/.vimrc).

I haven't aimed for complete reproduction here though, I've aimed to both trim the fat and also to use newer lua plugins in place of some of the older ones I used to use.

- Use [comment.nvim](https://github.com/numToStr/Comment.nvim) instead of [vim-commentary](https://github.com/tpope/vim-commentary)
- Use [telescope](https://github.com/nvim-telescope/telescope.nvim) instead of [ctrlp](https://github.com/kien/ctrlp.vim)
- Adds [whichkey]() into the mix to help me remember my custom keybindings
- Keeps a couple of excellent plugins from tpope (they're irreplaceable! ❤️ ):
    - [vim-fugitive](https://github.com/tpope/vim-fugitive)
    - [vim-sleuth](https://github.com/tpope/vim-sleuth)
    - [vim-surround](https://github.com/tpope/vim-surround)