### PR TITLE
Add LSP support

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -264,6 +264,22 @@
         "type": "github"
       }
     },
+    "plugin:trouble-nvim": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690614197,
+        "narHash": "sha256-Ee0AM8S/A8DU0hyOnZoKC1hkW0fvk0A+c3WGvPqmKcU=",
+        "owner": "folke",
+        "repo": "trouble.nvim",
+        "rev": "40aad004f53ae1d1ba91bcc5c29d59f07c5f01d3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "folke",
+        "repo": "trouble.nvim",
+        "type": "github"
+      }
+    },
     "plugin:vim-fugitive": {
       "flake": false,
       "locked": {
@@ -361,6 +377,7 @@
         "plugin:plenary-nvim": "plugin:plenary-nvim",
         "plugin:rose-pine": "plugin:rose-pine",
         "plugin:telescope-nvim": "plugin:telescope-nvim",
+        "plugin:trouble-nvim": "plugin:trouble-nvim",
         "plugin:vim-fugitive": "plugin:vim-fugitive",
         "plugin:vim-ledger": "plugin:vim-ledger",
         "plugin:vim-sleuth": "plugin:vim-sleuth",

--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,22 @@
         "type": "github"
       }
     },
+    "plugin:nvim-lspconfig": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690356683,
+        "narHash": "sha256-Ama9nLC/T1wJWal6bKvgY0ywUUiJ5VLuIxoY1xbJKtY=",
+        "owner": "neovim",
+        "repo": "nvim-lspconfig",
+        "rev": "b6091272422bb0fbd729f7f5d17a56d37499c54f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "neovim",
+        "repo": "nvim-lspconfig",
+        "type": "github"
+      }
+    },
     "plugin:nvim-treesitter-context": {
       "flake": false,
       "locked": {
@@ -220,6 +236,7 @@
         "neovim": "neovim",
         "nixpkgs": "nixpkgs",
         "plugin:comment-nvim": "plugin:comment-nvim",
+        "plugin:nvim-lspconfig": "plugin:nvim-lspconfig",
         "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
         "plugin:plenary-nvim": "plugin:plenary-nvim",
         "plugin:rose-pine": "plugin:rose-pine",

--- a/flake.lock
+++ b/flake.lock
@@ -55,6 +55,22 @@
         "type": "github"
       }
     },
+    "plugin:cmp-buffer": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1660101488,
+        "narHash": "sha256-dG4U7MtnXThoa/PD+qFtCt76MQ14V1wX8GMYcvxEnbM=",
+        "owner": "hrsh7th",
+        "repo": "cmp-buffer",
+        "rev": "3022dbc9166796b644a841a02de8dd1cc1d311fa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-buffer",
+        "type": "github"
+      }
+    },
     "plugin:cmp-nvim-lsp": {
       "flake": false,
       "locked": {
@@ -68,6 +84,38 @@
       "original": {
         "owner": "hrsh7th",
         "repo": "cmp-nvim-lsp",
+        "type": "github"
+      }
+    },
+    "plugin:cmp-nvim-lua": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1681458603,
+        "narHash": "sha256-6eXOK1mVK06TN1akhN42Bo4wQpeen3rk3b/m7iVmGKM=",
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lua",
+        "rev": "f12408bdb54c39c23e67cab726264c10db33ada8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lua",
+        "type": "github"
+      }
+    },
+    "plugin:cmp-path": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1664784283,
+        "narHash": "sha256-thppiiV3wjIaZnAXmsh7j3DUc6ceSCvGzviwFUnoPaI=",
+        "owner": "hrsh7th",
+        "repo": "cmp-path",
+        "rev": "91ff86cd9c29299a64f968ebb45846c485725f23",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-path",
         "type": "github"
       }
     },
@@ -300,7 +348,10 @@
       "inputs": {
         "neovim": "neovim",
         "nixpkgs": "nixpkgs",
+        "plugin:cmp-buffer": "plugin:cmp-buffer",
         "plugin:cmp-nvim-lsp": "plugin:cmp-nvim-lsp",
+        "plugin:cmp-nvim-lua": "plugin:cmp-nvim-lua",
+        "plugin:cmp-path": "plugin:cmp-path",
         "plugin:comment-nvim": "plugin:comment-nvim",
         "plugin:lsp-zero": "plugin:lsp-zero",
         "plugin:luasnip": "plugin:luasnip",

--- a/flake.lock
+++ b/flake.lock
@@ -55,6 +55,22 @@
         "type": "github"
       }
     },
+    "plugin:cmp-nvim-lsp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687494203,
+        "narHash": "sha256-mU0soCz79erJXMMqD/FyrJZ0mu2n6fE0deymPzQlxts=",
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lsp",
+        "rev": "44b16d11215dce86f253ce0c30949813c0a90765",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "cmp-nvim-lsp",
+        "type": "github"
+      }
+    },
     "plugin:comment-nvim": {
       "flake": false,
       "locked": {
@@ -68,6 +84,55 @@
       "original": {
         "owner": "numToStr",
         "repo": "Comment.nvim",
+        "type": "github"
+      }
+    },
+    "plugin:lsp-zero": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690547138,
+        "narHash": "sha256-zIb/7s/xBYEYtTBPtPQUyktSu5aHG+mlWoYRmoo+vu4=",
+        "owner": "VonHeikemen",
+        "repo": "lsp-zero.nvim",
+        "rev": "ef56e4c6cbcf95e807a89140ab1c87d22f5ea067",
+        "type": "github"
+      },
+      "original": {
+        "owner": "VonHeikemen",
+        "ref": "dev-v3",
+        "repo": "lsp-zero.nvim",
+        "type": "github"
+      }
+    },
+    "plugin:luasnip": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1690382684,
+        "narHash": "sha256-v4nCOg7FHBkpKJQZUimMi5ViB2spznngFSA7DcTYBkM=",
+        "owner": "L3MON4D3",
+        "repo": "LuaSnip",
+        "rev": "e81cbe6004051c390721d8570a4a0541ceb0df10",
+        "type": "github"
+      },
+      "original": {
+        "owner": "L3MON4D3",
+        "repo": "LuaSnip",
+        "type": "github"
+      }
+    },
+    "plugin:nvim-cmp": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1688965049,
+        "narHash": "sha256-Hq6YUfMQo1rHoay3/NieGCne7U/f06GwUPhN2HO0PdQ=",
+        "owner": "hrsh7th",
+        "repo": "nvim-cmp",
+        "rev": "c4e491a87eeacf0408902c32f031d802c7eafce8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hrsh7th",
+        "repo": "nvim-cmp",
         "type": "github"
       }
     },
@@ -235,7 +300,11 @@
       "inputs": {
         "neovim": "neovim",
         "nixpkgs": "nixpkgs",
+        "plugin:cmp-nvim-lsp": "plugin:cmp-nvim-lsp",
         "plugin:comment-nvim": "plugin:comment-nvim",
+        "plugin:lsp-zero": "plugin:lsp-zero",
+        "plugin:luasnip": "plugin:luasnip",
+        "plugin:nvim-cmp": "plugin:nvim-cmp",
         "plugin:nvim-lspconfig": "plugin:nvim-lspconfig",
         "plugin:nvim-treesitter-context": "plugin:nvim-treesitter-context",
         "plugin:plenary-nvim": "plugin:plenary-nvim",

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,23 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    "plugin:cmp-buffer" = {
+      url = github:hrsh7th/cmp-buffer;
+      flake = false;
+    };
+
     "plugin:cmp-nvim-lsp" = {
       url = github:hrsh7th/cmp-nvim-lsp;
+      flake = false;
+    };
+
+    "plugin:cmp-nvim-lua" = {
+      url = github:hrsh7th/cmp-nvim-lua;
+      flake = false;
+    };
+
+    "plugin:cmp-path" = {
+      url = github:hrsh7th/cmp-path;
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -8,8 +8,28 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
+    "plugin:cmp-nvim-lsp" = {
+      url = github:hrsh7th/cmp-nvim-lsp;
+      flake = false;
+    };
+
     "plugin:comment-nvim" = {
       url = github:numToStr/Comment.nvim;
+      flake = false;
+    };
+
+    "plugin:lsp-zero" = {
+      url = github:VonHeikemen/lsp-zero.nvim/dev-v3;
+      flake = false;
+    };
+
+    "plugin:luasnip" = {
+      url = github:L3MON4D3/LuaSnip;
+      flake = false;
+    };
+
+    "plugin:nvim-cmp" = {
+      url = github:hrsh7th/nvim-cmp;
       flake = false;
     };
 
@@ -23,13 +43,13 @@
       flake = false;
     };
 
-    "plugin:rose-pine" = {
-      url = github:rose-pine/neovim;
+    "plugin:plenary-nvim" = {
+      url = github:nvim-lua/plenary.nvim;
       flake = false;
     };
 
-    "plugin:plenary-nvim" = {
-      url = github:nvim-lua/plenary.nvim;
+    "plugin:rose-pine" = {
+      url = github:rose-pine/neovim;
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,11 @@
       flake = false;
     };
 
+    "plugin:nvim-lspconfig" = {
+      url = github:neovim/nvim-lspconfig;
+      flake = false;
+    };
+
     "plugin:nvim-treesitter-context" = {
       url = github:nvim-treesitter/nvim-treesitter-context;
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,11 @@
       flake = false;
     };
 
+    "plugin:trouble-nvim" = {
+      url = github:folke/trouble.nvim;
+      flake = false;
+    };
+
     "plugin:vim-fugitive" = {
       url = github:tpope/vim-fugitive;
       flake = false;

--- a/pkgs/bundle.nix
+++ b/pkgs/bundle.nix
@@ -9,6 +9,7 @@
 }: rec {
   config = pkgs.callPackage ./config {inherit pkgs appName;};
   neovim = pkgs.callPackage ./neovim {
-    inherit pkgs lib config appName viAlias vimAlias isolated extraPackages;
+    inherit pkgs lib config appName viAlias vimAlias isolated;
+    extraPackages = extraPackages ++ [pkgs.lua-language-server pkgs.nil] ++ [pkgs.nodePackages.typescript-language-server pkgs.nodePackages.bash-language-server];
   };
 }

--- a/pkgs/bundle.nix
+++ b/pkgs/bundle.nix
@@ -9,7 +9,6 @@
 }: rec {
   config = pkgs.callPackage ./config {inherit pkgs appName;};
   neovim = pkgs.callPackage ./neovim {
-    inherit pkgs lib config appName viAlias vimAlias isolated;
-    extraPackages = extraPackages ++ [pkgs.lua-language-server pkgs.nil] ++ [pkgs.nodePackages.typescript-language-server pkgs.nodePackages.bash-language-server];
+    inherit pkgs lib config appName viAlias vimAlias isolated extraPackages;
   };
 }

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -1,6 +1,27 @@
 local lsp = require("lsp-zero").preset({})
 
 -- Enable autocomplete
+lsp.extend_cmp()
+local cmp = require("cmp")
+
+cmp.setup({
+    -- Disable autocompletion, require manual trigger
+    completion = {
+        autocomplete = false,
+    },
+    -- Use ctrl+space to trigger completion menu
+    mapping = {
+        ["<C-Space>"] = cmp.mapping.complete(),
+    },
+    -- Set sources (and priority) to complete from
+    sources = {
+        { name = "path" },
+        { name = "nvim_lsp" },
+        { name = "buffer" },
+        { name = "nvim_lua" },
+    },
+})
+
 lsp.on_attach(function(client, bufnr)
     local opts = function(desc)
         return {

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -1,5 +1,59 @@
 local lsp = require("lsp-zero").preset({})
 
+-- Enable autocomplete
+lsp.on_attach(function(client, bufnr)
+    local opts = function(desc)
+        return {
+            buffer = bufnr,
+            desc = desc,
+            remap = false,
+        }
+    end
+
+    -- Navigation
+    vim.keymap.set("n", "gd", function()
+        vim.lsp.buf.definition()
+    end, opts("Go to Definition of symbol"))
+
+    vim.keymap.set("n", "gD", function()
+        vim.lsp.buf.declaration()
+    end, opts("Go to Declaration of symbol"))
+
+    vim.keymap.set("n", "gt", function()
+        vim.lsp.buf.type_definition()
+    end, opts("Go to definition of Type"))
+
+    vim.keymap.set("n", "[d", function()
+        vim.diagnostic.goto_prev()
+    end, opts("Go to previous diagnostic"))
+
+    vim.keymap.set("n", "]d", function()
+        vim.diagnostic.goto_next()
+    end, opts("Go to next diagnostic"))
+
+    -- Hints
+    vim.keymap.set("n", "K", function()
+        vim.lsp.buf.hover()
+    end, opts("Hover: Show info about symbol"))
+
+    vim.keymap.set("i", "<C-h>", function()
+        vim.lsp.buf.signature_help()
+    end, opts("Show signature of symbol"))
+
+    -- Actions
+    vim.keymap.set("n", "<leader>la", function()
+        vim.lsp.buf.code_action()
+    end, opts("Lsp: code Action"))
+
+    vim.keymap.set("n", "<leader>lr", function()
+        vim.lsp.buf.rename()
+    end, opts("Lsp: Rename symbol"))
+
+    vim.keymap.set("n", "<leader>lR", function()
+        vim.lsp.buf.references()
+    end, opts("Lsp: find all References"))
+end)
+
 lsp.setup_servers({
     "bashls",
     "lua_ls",

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -1,6 +1,10 @@
-local lspconfig = require("lspconfig")
+local lsp = require("lsp-zero").preset({})
 
-lspconfig.bashls.setup({})
-lspconfig.lua_ls.setup({})
-lspconfig.nil_ls.setup({})
-lspconfig.tsserver.setup({})
+lsp.setup_servers({
+    "bashls",
+    "lua_ls",
+    "nil_ls",
+    "tsserver",
+})
+
+require("lspconfig").lua_ls.setup(lsp.nvim_lua_ls())

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -54,6 +54,13 @@ lsp.on_attach(function(client, bufnr)
     end, opts("Lsp: find all References"))
 end)
 
+-- Turn off the semantic highlighting (treesitter seems to be way better)
+lsp.set_server_config({
+    on_init = function(client)
+        client.server_capabilities.semanticTokensProvider = nil
+    end,
+})
+
 lsp.setup_servers({
     "bashls",
     "lua_ls",

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -1,0 +1,6 @@
+local lspconfig = require("lspconfig")
+
+lspconfig.bashls.setup({})
+lspconfig.lua_ls.setup({})
+lspconfig.nil_ls.setup({})
+lspconfig.tsserver.setup({})

--- a/pkgs/config/after/plugin/lsp.lua
+++ b/pkgs/config/after/plugin/lsp.lua
@@ -66,13 +66,23 @@ lsp.on_attach(function(client, bufnr)
         vim.lsp.buf.code_action()
     end, opts("Lsp: code Action"))
 
-    vim.keymap.set("n", "<leader>lr", function()
-        vim.lsp.buf.rename()
-    end, opts("Lsp: Rename symbol"))
+    vim.keymap.set(
+        "n",
+        "<leader>ld",
+        "<cmd>TroubleToggle document_diagnostics<cr>",
+        opts("Lsp: show all Diagnostics in trouble.nvim")
+    )
+
+    vim.keymap.set(
+        "n",
+        "<leader>lr",
+        "<cmd>TroubleToggle lsp_references<cr>",
+        opts("Lsp: find all References in trouble.nvim")
+    )
 
     vim.keymap.set("n", "<leader>lR", function()
-        vim.lsp.buf.references()
-    end, opts("Lsp: find all References"))
+        vim.lsp.buf.rename()
+    end, opts("Lsp: Rename symbol"))
 end)
 
 -- Turn off the semantic highlighting (treesitter seems to be way better)

--- a/pkgs/config/after/plugin/telescope.lua
+++ b/pkgs/config/after/plugin/telescope.lua
@@ -1,3 +1,15 @@
+local telescope = require("telescope")
+local trouble = require("trouble.providers.telescope")
+
+telescope.setup({
+    defaults = {
+        mappings = {
+            i = { ["<C-t>"] = trouble.open_with_trouble },
+            n = { ["<C-t>"] = trouble.open_with_trouble },
+        },
+    },
+})
+
 local builtin = require("telescope.builtin")
 
 -- Find files

--- a/pkgs/config/after/plugin/trouble.lua
+++ b/pkgs/config/after/plugin/trouble.lua
@@ -1,4 +1,4 @@
-require("trouble").setup({
+local trouble = require("trouble").setup({
     icons = false,
     fold_open = "▼",
     fold_closed = "▶",
@@ -19,3 +19,22 @@ vim.keymap.set("n", "<leader>tq", "<cmd>TroubleToggle quickfix<cr>", {
     noremap = true,
     desc = "Toggle the trouble.nvim Quickfix list",
 })
+
+-- vim-unimpaired -style navigation
+local opts = { skip_groups = true, jump = true }
+
+vim.keymap.set("n", "[t", function()
+    trouble.previous(opts)
+end, { desc = "Go to previous file in Trouble" })
+
+vim.keymap.set("n", "]t", function()
+    trouble.next(opts)
+end, { desc = "Go to previous file in Trouble" })
+
+vim.keymap.set("n", "[T", function()
+    trouble.first(opts)
+end, { desc = "Go to first file in Trouble" })
+
+vim.keymap.set("n", "]T", function()
+    trouble.last(opts)
+end, { desc = "Go to last file in Trouble" })

--- a/pkgs/config/after/plugin/trouble.lua
+++ b/pkgs/config/after/plugin/trouble.lua
@@ -1,0 +1,21 @@
+require("trouble").setup({
+    icons = false,
+    fold_open = "▼",
+    fold_closed = "▶",
+    use_diagnostic_signs = true,
+    signs = {
+        other = "◦",
+    },
+})
+
+vim.keymap.set("n", "<leader>tt", "<cmd>TroubleToggle<cr>", {
+    silent = true,
+    noremap = true,
+    desc = "Toggle the last Trouble.nvim list",
+})
+
+vim.keymap.set("n", "<leader>tq", "<cmd>TroubleToggle quickfix<cr>", {
+    silent = true,
+    noremap = true,
+    desc = "Toggle the trouble.nvim Quickfix list",
+})

--- a/pkgs/config/lua/jagd/hooks.lua
+++ b/pkgs/config/lua/jagd/hooks.lua
@@ -19,11 +19,11 @@ local extra_whitespace_group = augroup("extra_whitespace", { clear = true })
 vim.api.nvim_set_hl(0, "ExtraWhitespace", { bg = "red" })
 autocmd("InsertEnter", {
     group = extra_whitespace_group,
-    pattern = "*",
+    pattern = "*\\(Trouble\\)\\@<!",
     command = "match ExtraWhitespace /\\s\\+\\%#\\@<!$/",
 })
 autocmd("InsertLeave", {
     group = extra_whitespace_group,
-    pattern = "*",
+    pattern = "*\\(Trouble\\)\\@<!",
     command = "match ExtraWhitespace /\\s\\+$/",
 })

--- a/pkgs/config/lua/jagd/keymaps.lua
+++ b/pkgs/config/lua/jagd/keymaps.lua
@@ -15,17 +15,26 @@ vim.keymap.set("n", "<C-u>", "<C-u>zz")
 vim.keymap.set("n", "n", "nzzzv")
 vim.keymap.set("n", "N", "Nzzzv")
 
+-- Make yanking/pasting a bit easier
 vim.keymap.set(
     { "n", "v" },
     "<leader>y",
     [["+y]],
     { desc = "Copy to system clipboard" }
 )
+
 vim.keymap.set(
     "n",
     "<leader>Y",
     [["+Y]],
     { desc = "Copy rest of line to system clipboard" }
+)
+
+vim.keymap.set(
+    "x",
+    "<leader>p",
+    [["_dP]],
+    { desc = "Paste over visual selection without losing register contents" }
 )
 
 -- Stop accidentally pressing Q
@@ -37,11 +46,83 @@ vim.keymap.set("v", "K", ":m '<-2<CR>gv=gv")
 
 -- Re-select selection after indenting in visual mode
 vim.keymap.set("v", ">", ">gv")
-vim.keymap.set("v", ">", "<gv")
+vim.keymap.set("v", "<", "<gv")
 
+-- Stolen from vim-unimpaired
+-- Navigate :args
 vim.keymap.set(
-    "x",
-    "<leader>p",
-    [["_dP]],
-    { desc = "Paste over visual selection without losing register contents" }
+    "n",
+    "[a",
+    ":previous<CR>",
+    { desc = "Go to previous file in args list" }
+)
+vim.keymap.set(
+    "n",
+    "]a",
+    ":next<CR>",
+    { desc = "Go to next file in args list" }
+)
+vim.keymap.set(
+    "n",
+    "[A",
+    ":first<CR>",
+    { desc = "Go to first file in args list" }
+)
+vim.keymap.set(
+    "n",
+    "]A",
+    ":last<CR>",
+    { desc = "Go to last file in args list" }
+)
+
+-- Navigate :buffers
+vim.keymap.set(
+    "n",
+    "[b",
+    ":bprevious<CR>",
+    { desc = "Go to previous file in buffer list" }
+)
+vim.keymap.set(
+    "n",
+    "]b",
+    ":bnext<CR>",
+    { desc = "Go to next file in buffer list" }
+)
+vim.keymap.set(
+    "n",
+    "[B",
+    ":bfirst<CR>",
+    { desc = "Go to first file in buffer list" }
+)
+vim.keymap.set(
+    "n",
+    "]B",
+    ":blast<CR>",
+    { desc = "Go to last file in buffer list" }
+)
+
+-- Navigate quickfix list
+vim.keymap.set(
+    "n",
+    "[q",
+    ":cprevious<CR>",
+    { desc = "Go to previous file in quickfix list" }
+)
+vim.keymap.set(
+    "n",
+    "]q",
+    ":cnext<CR>",
+    { desc = "Go to next file in quickfix list" }
+)
+vim.keymap.set(
+    "n",
+    "[Q",
+    ":cfirst<CR>",
+    { desc = "Go to first file in quickfix list" }
+)
+vim.keymap.set(
+    "n",
+    "]Q",
+    ":clast<CR>",
+    { desc = "Go to last file in quickfix list" }
 )

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -22,7 +22,10 @@
 
   plugins =
     (with pkgs.neovimPlugins; [
+      cmp-buffer
       cmp-nvim-lsp
+      cmp-nvim-lua
+      cmp-path
       comment-nvim
       lsp-zero
       luasnip

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -22,7 +22,11 @@
 
   plugins =
     (with pkgs.neovimPlugins; [
+      cmp-nvim-lsp
       comment-nvim
+      lsp-zero
+      luasnip
+      nvim-cmp
       nvim-lspconfig
       nvim-treesitter-context
       plenary-nvim

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -10,6 +10,7 @@
 }: let
   plugins = [
     pkgs.neovimPlugins.comment-nvim
+    pkgs.neovimPlugins.nvim-lspconfig
     pkgs.neovimPlugins.nvim-treesitter-context
     pkgs.neovimPlugins.plenary-nvim
     pkgs.neovimPlugins.rose-pine

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -35,6 +35,7 @@
       plenary-nvim
       rose-pine
       telescope-nvim
+      trouble-nvim
       vim-fugitive
       vim-ledger
       vim-sleuth

--- a/pkgs/neovim/default.nix
+++ b/pkgs/neovim/default.nix
@@ -8,20 +8,33 @@
   isolated ? true,
   extraPackages ? [],
 }: let
-  plugins = [
-    pkgs.neovimPlugins.comment-nvim
-    pkgs.neovimPlugins.nvim-lspconfig
-    pkgs.neovimPlugins.nvim-treesitter-context
-    pkgs.neovimPlugins.plenary-nvim
-    pkgs.neovimPlugins.rose-pine
-    pkgs.neovimPlugins.telescope-nvim
-    pkgs.neovimPlugins.vim-fugitive
-    pkgs.neovimPlugins.vim-ledger
-    pkgs.neovimPlugins.vim-sleuth
-    pkgs.neovimPlugins.vim-surround
-    pkgs.neovimPlugins.which-key-nvim
-    pkgs.vimPlugins.nvim-treesitter.withAllGrammars
-  ];
+  lsps =
+    (with pkgs; [
+      lua-language-server
+      nil
+    ])
+    ++ (with pkgs.nodePackages; [
+      bash-language-server
+      typescript-language-server
+    ]);
+
+  runtimePackages = lsps ++ extraPackages;
+
+  plugins =
+    (with pkgs.neovimPlugins; [
+      comment-nvim
+      nvim-lspconfig
+      nvim-treesitter-context
+      plenary-nvim
+      rose-pine
+      telescope-nvim
+      vim-fugitive
+      vim-ledger
+      vim-sleuth
+      vim-surround
+      which-key-nvim
+    ])
+    ++ [pkgs.vimPlugins.nvim-treesitter.withAllGrammars];
 
   nvimConfig = pkgs.neovimUtils.makeNeovimConfig {
     inherit plugins viAlias vimAlias;
@@ -35,8 +48,6 @@
     data = "/tmp/nvim-data";
     state = "/tmp/nvim-state";
   };
-
-  hasExtraPackages = extraPackages != [];
 in
   pkgs.wrapNeovimUnstable pkgs.neovim
   (
@@ -44,7 +55,7 @@ in
     // {
       wrapperArgs = lib.escapeShellArgs (nvimConfig.wrapperArgs
         ++ ["--set" "NVIM_APPNAME" appName]
-        ++ lib.optionals hasExtraPackages ["--suffix" "PATH" ":" "${lib.makeBinPath extraPackages}"]
+        ++ ["--suffix" "PATH" ":" "${lib.makeBinPath runtimePackages}"]
         ++ lib.optionals isolated [
           "--set"
           "XDG_CONFIG_HOME"


### PR DESCRIPTION
Install and configure:
 - [LSP Zero](https://github.com/VonHeikemen/lsp-zero.nvim), with:
     - [nvim-cmp](https://github.com/hrsh7th/nvim-cmp) for completion, with a number of completion sources:
         - [cmp-nvim-lsp](https://github.com/hrsh7th/cmp-nvim-lsp) for completing from the LSP
         - [cmp-buffer](https://github.com/hrsh7th/cmp-buffer) for completing from the current buffer
         - [cmp-path](https://github.com/hrsh7th/cmp-path) for completing filepaths
         - [cmp-nvim-lua](https://github.com/hrsh7th/cmp-nvim-lua) for completing from the neovim lua API
     - [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) to provide default configs for language servers
     - All attempts to auto-install language servers with [mason.nvim](https://github.com/williamboman/mason.nvim) disabled, as I'm managing them through nix
     - Autocompletion turned off, but manually triggered with ctrl-space
     - LSP-based syntax highlighting turned off, as treesitter does a better job
 - Language servers for:
     - Bash
     - Lua
     - Nix
     - TypeScript
 - [Trouble.nvim](https://github.com/folke/trouble.nvim) for better display of LSP diagnostics and references

Also sets up a bunch of keymaps for LSP-related navigation and functions (goto definition, find references, etc), as well as pinching a couple of keymaps from [vim-unimpaired](https://github.com/tpope/vim-unimpaired).